### PR TITLE
Enable usage of FDQN and PROTO to customize external endpoint address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,16 @@
         "express-basic-auth": "^1.2.1",
         "morgan": "^1.10.0",
         "node-fetch": "^3.3.0",
-        "superstruct": "^1.0.3"
+        "superstruct": "^1.0.3",
+        "ws": "^8.12.0"
       },
       "devDependencies": {
+        "@types/basic-auth": "^1.1.3",
         "@types/better-sqlite3": "^7.6.3",
         "@types/express": "^4.17.15",
         "@types/morgan": "^1.9.3",
         "@types/node": "^18.11.17",
+        "@types/ws": "^8.5.4",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
       }
@@ -86,6 +89,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "node_modules/@types/basic-auth": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.3.tgz",
+      "integrity": "sha512-W3rv6J0IGlxqgE2eQ2pTb0gBjaGtejQpJ6uaCjz3UQ65+TFTPC5/lAE+POfx1YLdjtxvejJzsIAfd3MxWiVmfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.3",
@@ -178,6 +190,15 @@
       "dev": true,
       "dependencies": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "dev": true,
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -1425,6 +1446,26 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
+    "node_modules/ws": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1495,6 +1536,15 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
+    },
+    "@types/basic-auth": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.3.tgz",
+      "integrity": "sha512-W3rv6J0IGlxqgE2eQ2pTb0gBjaGtejQpJ6uaCjz3UQ65+TFTPC5/lAE+POfx1YLdjtxvejJzsIAfd3MxWiVmfg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/better-sqlite3": {
       "version": "7.6.3",
@@ -1587,6 +1637,15 @@
       "dev": true,
       "requires": {
         "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "dev": true,
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -2456,6 +2515,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "requires": {}
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/basic-auth": "^1.1.3",
     "@types/better-sqlite3": "^7.6.3",
     "@types/express": "^4.17.15",
     "@types/morgan": "^1.9.3",
     "@types/node": "^18.11.17",
+    "@types/ws": "^8.5.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   },
@@ -26,6 +28,7 @@
     "express-basic-auth": "^1.2.1",
     "morgan": "^1.10.0",
     "node-fetch": "^3.3.0",
-    "superstruct": "^1.0.3"
+    "superstruct": "^1.0.3",
+    "ws": "^8.12.0"
   }
 }

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { Router } from "express";
+import WebSocket from 'ws';
 
 import {
   createFollower,
@@ -96,6 +97,13 @@ activitypub.post("/:actor/inbox", async (req, res) => {
       break;
     }
   }
+
+  // Notify listening websockets of new activity
+  req.app.get("wss").clients.forEach(function each(client: WebSocket) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(req.body, { binary: false });
+    }
+  });
 
   return res.sendStatus(204);
 });

--- a/src/activitypub.ts
+++ b/src/activitypub.ts
@@ -11,7 +11,7 @@ import {
   listPosts,
   updateFollowing,
 } from "./db.js";
-import { HOSTNAME, ACCOUNT, PUBLIC_KEY } from "./env.js";
+import { HOSTNAME, PORT, ACCOUNT, PUBLIC_KEY, PROTO, FDQN } from "./env.js";
 import { send, verify } from "./request.js";
 
 export const activitypub = Router();
@@ -59,11 +59,14 @@ activitypub.post("/:actor/inbox", async (req, res) => {
   // ensure that the verified actor matches the actor in the request body
   if (from !== body.actor) return res.sendStatus(401);
 
+  const endpoint: string = (FDQN != null ? FDQN: `${HOSTNAME}:${PORT}`);
+  const uri = `${PROTO}://${endpoint}/${crypto.randomUUID()}`;
+
   switch (body.type) {
     case "Follow": {
       await send(actor, body.actor, {
         "@context": "https://www.w3.org/ns/activitystreams",
-        id: `https://${HOSTNAME}/${crypto.randomUUID()}`,
+        id: uri,
         type: "Accept",
         actor,
         object: body,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -4,7 +4,7 @@ import { is, omit, type } from "superstruct";
 import { Router } from "express";
 import basicAuth from "express-basic-auth";
 
-import { ADMIN_PASSWORD, ADMIN_USERNAME, HOSTNAME } from "./env.js";
+import { ADMIN_PASSWORD, ADMIN_USERNAME, HOSTNAME, PORT, PROTO, FDQN } from "./env.js";
 import {
   createFollowing,
   createPost,
@@ -61,11 +61,14 @@ admin.post("/create", async (req, res) => {
   return res.sendStatus(204);
 });
 
-admin.post("/follow/:actor", async (req, res) => {
+admin.post("/follow/:actor/:hostname/:port/:proto", async (req, res) => {
   const actor: string = req.app.get("actor");
 
-  const object = req.params.actor;
-  const uri = `https://${HOSTNAME}/@${crypto.randomUUID()}`;
+  const object = (({ proto, hostname, port, actor }) => {
+    return `${proto}://${hostname}:${port}/${actor}`;
+  })(req.params);
+  const endpoint: string = (FDQN != null ? FDQN: `${HOSTNAME}:${PORT}`);
+  const uri = `${PROTO}://${endpoint}/@${crypto.randomUUID()}`;
   await send(actor, object, {
     "@context": "https://www.w3.org/ns/activitystreams",
     id: uri,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -47,13 +47,13 @@ admin.post("/create", async (req, res) => {
     to: ["https://www.w3.org/ns/activitystreams#Public"],
     cc: [`${actor}/followers`],
     ...body,
-    object: { ...object.contents, id: `${actor}/post/${object.id}` },
+    object: { ...object.contents, id: `${actor}/posts/${object.id}` },
   });
 
   for (const follower of listFollowers()) {
     send(actor, follower.actor, {
       ...activity.contents,
-      id: `${actor}/post/${activity.id}`,
+      id: `${actor}/posts/${activity.id}`,
       cc: [follower.actor],
     });
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+export const WEBHOOK_PATH = process.env.WEBHOOK_PATH || "webhook";
 export const FDQN = process.env.FDQN || null;
 export const PROTO = process.env.PROTO || "https";
 export const PORT = process.env.PORT || "3000";

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,6 +4,8 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+export const FDQN = process.env.FDQN || null;
+export const PROTO = process.env.PROTO || "https";
 export const PORT = process.env.PORT || "3000";
 
 export const ACCOUNT = process.env.ACCOUNT || "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,79 @@
 import express from "express";
 import morgan from "morgan";
+import http from "http";
+import WebSocket, { WebSocketServer } from 'ws';
+import auth from 'basic-auth';
 
-import { ACCOUNT, HOSTNAME, PORT, PROTO, FDQN } from "./env.js";
+import { ADMIN_USERNAME, ADMIN_PASSWORD, ACCOUNT, HOSTNAME, PORT, PROTO, FDQN } from "./env.js";
 import { activitypub } from "./activitypub.js";
 import { admin } from "./admin.js";
 import { webhook } from "./webhook.js";
+import safeCompare from "./safeCompare.js";
 
 const app = express();
+
+const server = http.createServer(app);
+
+const wss = new WebSocketServer({noServer: true, path: "/listen/websocket"});
+app.set("wss", wss);
+
+function onSocketError(err: any) {
+  console.error(err);
+}
+
+wss.on('connection', function connection(ws: any) {
+  ws.isAlive = true;
+  ws.on('error', onSocketError);
+  ws.on('pong', (ws: any) => {
+    ws.isAlive = true;
+  });
+});
+
+// Ping every 30 seconds
+const interval = setInterval(function ping() {
+  // With WebSocket for type annotation isAlive is not a property
+  wss.clients.forEach(function each(ws: any) {
+    if (ws.isAlive === false) return ws.terminate();
+
+    ws.isAlive = false;
+    ws.ping();
+  });
+}, 30000);
+
+wss.on('close', function close() {
+  clearInterval(interval);
+});
+
+// Basic function to validate credentials
+function check (name: string, pass: string): boolean {
+  var valid = true
+
+  // Simple method to prevent short-circut and use timing-safe compare
+  valid = safeCompare(name, ADMIN_USERNAME) && valid
+  valid = safeCompare(pass, ADMIN_PASSWORD) && valid
+
+  return valid
+}
+
+server.on('upgrade', function upgrade(req: any, socket: any, head: any) {
+  // In case of error within upgrade
+  socket.on('error', onSocketError);
+  // Get credentials
+  const credentials = auth(req);
+  // Check credentials
+  if (!credentials || !check(credentials.name, credentials.pass)) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    // TODO realm as public key or content address of, or DID
+    // socket.write('WWW-Authenticate: Basic realm="example"\r\n\r\n');
+    socket.removeListener('error', onSocketError);
+    socket.destroy();
+    return;
+  }
+  // Do the upgrade if credentials check out
+  wss.handleUpgrade(req, socket, head, function done(ws: WebSocket) {
+    wss.emit('connection', ws, req, head);
+  });
+})
 
 const endpoint: string = (FDQN != null ? FDQN: `${HOSTNAME}:${PORT}`);
 
@@ -39,6 +106,6 @@ app.get("/.well-known/webfinger", async (req, res) => {
 app.use("/admin", admin).use(activitypub);
 app.use("/webhook", webhook);
 
-app.listen(PORT, () => {
+server.listen(PORT, () => {
   console.log(`Dumbo listening on port ${PORT}…`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import morgan from "morgan";
 import { ACCOUNT, HOSTNAME, PORT, PROTO, FDQN } from "./env.js";
 import { activitypub } from "./activitypub.js";
 import { admin } from "./admin.js";
+import { webhook } from "./webhook.js";
 
 const app = express();
 
@@ -36,6 +37,7 @@ app.get("/.well-known/webfinger", async (req, res) => {
 });
 
 app.use("/admin", admin).use(activitypub);
+app.use("/webhook", webhook);
 
 app.listen(PORT, () => {
   console.log(`Dumbo listening on port ${PORT}…`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 import express from "express";
 import morgan from "morgan";
 
-import { ACCOUNT, HOSTNAME, PORT } from "./env.js";
+import { ACCOUNT, HOSTNAME, PORT, PROTO, FDQN } from "./env.js";
 import { activitypub } from "./activitypub.js";
 import { admin } from "./admin.js";
 
 const app = express();
 
-app.set("actor", `https://${HOSTNAME}/${ACCOUNT}`);
+const endpoint: string = (FDQN != null ? FDQN: `${HOSTNAME}:${PORT}`);
+
+app.set("actor", `${PROTO}://${endpoint}/${ACCOUNT}`);
 
 app.use(
   express.text({ type: ["application/json", "application/activity+json"] })
@@ -19,10 +21,10 @@ app.get("/.well-known/webfinger", async (req, res) => {
   const actor: string = req.app.get("actor");
 
   const resource = req.query.resource;
-  if (resource !== `acct:${ACCOUNT}@${HOSTNAME}`) return res.sendStatus(404);
+  if (resource !== `acct:${ACCOUNT}@${endpoint}`) return res.sendStatus(404);
 
   return res.contentType("application/activity+json").json({
-    subject: `acct:${ACCOUNT}@${HOSTNAME}`,
+    subject: `acct:${ACCOUNT}@${endpoint}`,
     links: [
       {
         rel: "self",

--- a/src/request.ts
+++ b/src/request.ts
@@ -31,7 +31,7 @@ export async function send(sender: string, recipient: string, message: object) {
   const url = new URL(recipient);
 
   const actor = await fetchActor(recipient);
-  const fragment = actor.inbox.replace("https://" + url.hostname, "");
+  const fragment = url.pathname + "/inbox";
   const body = JSON.stringify(message);
   const digest = crypto.createHash("sha256").update(body).digest("base64");
   const d = new Date();

--- a/src/safeCompare.ts
+++ b/src/safeCompare.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// Upstream: https://github.com/LionC/express-basic-auth/blob/dd17b4de9fee9558269cdc583310bde5331456e7/index.js#L1-L17
+import { timingSafeEqual } from 'crypto';
+
+
+// Credits for the actual algorithm go to github/@Bruce17
+// Thanks to github/@hraban for making me implement this
+export default function safeCompare(userInput: string, secret: string): boolean {
+    const userInputLength = Buffer.byteLength(userInput)
+    const secretLength = Buffer.byteLength(secret)
+
+    const userInputBuffer = Buffer.alloc(userInputLength, 0, 'utf8')
+    userInputBuffer.write(userInput)
+    const secretBuffer = Buffer.alloc(userInputLength, 0, 'utf8')
+    secretBuffer.write(secret)
+
+    return !!(Number(timingSafeEqual(userInputBuffer, secretBuffer)) & Number(userInputLength === secretLength))
+
+}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -38,13 +38,13 @@ webhook.post(`/${WEBHOOK_PATH}`, async (req, res) => {
     to: ["https://www.w3.org/ns/activitystreams#Public"],
     cc: [`${actor}/followers`],
     ...body,
-    object: { ...object.contents, id: `${actor}/post/${object.id}` },
+    object: { ...object.contents, id: `${actor}/posts/${object.id}` },
   });
 
   for (const follower of listFollowers()) {
     send(actor, follower.actor, {
       ...activity.contents,
-      id: `${actor}/post/${activity.id}`,
+      id: `${actor}/posts/${activity.id}`,
       cc: [follower.actor],
     });
   }

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,0 +1,53 @@
+import { is, omit, type } from "superstruct";
+import { Router } from "express";
+
+import { WEBHOOK_PATH } from "./env.js";
+import {
+  createPost,
+  listFollowers,
+} from "./db.js";
+import { send } from "./request.js";
+import { Object } from "./types.js";
+
+export const webhook = Router();
+
+
+webhook.post(`/${WEBHOOK_PATH}`, async (req, res) => {
+  const actor: string = req.app.get("actor");
+
+  const create = type({ object: omit(Object, ["id"]) });
+
+  const body = {"object": {"type": "Note", "mediaType": "application/json", "content": req.body}};
+  if (!is(body, create)) return res.sendStatus(400);
+
+  const date = new Date();
+
+  const object = createPost({
+    attributedTo: actor,
+    published: date.toISOString(),
+    to: ["https://www.w3.org/ns/activitystreams#Public"],
+    cc: [`${actor}/followers`],
+    ...body.object,
+  });
+
+  const activity = createPost({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    type: "Create",
+    published: date.toISOString(),
+    actor,
+    to: ["https://www.w3.org/ns/activitystreams#Public"],
+    cc: [`${actor}/followers`],
+    ...body,
+    object: { ...object.contents, id: `${actor}/post/${object.id}` },
+  });
+
+  for (const follower of listFollowers()) {
+    send(actor, follower.actor, {
+      ...activity.contents,
+      id: `${actor}/post/${activity.id}`,
+      cc: [follower.actor],
+    });
+  }
+
+  return res.sendStatus(204);
+});


### PR DESCRIPTION
Enable usage of FDQN and PROTO to customize external endpoint address

```console    
$ ssh -R 80:localhost:8000 nokey@localhost.run &
8c0fe6b82d8db0.lhr.life tunneled with tls termination, https://8c0fe6b82d8db0.lhr.life
$ openssl genrsa -out keypair.pem 4096 && openssl rsa -in keypair.pem -pubout -out publickey.crt && openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in keypair.pem -out pkcs8.key
$ FDQN=8c0fe6b82d8db0.lhr.life PORT=8000 ADMIN_USERNAME=alice ADMIN_PASSWORD=alice PUBLIC_KEY=$(cat publickey.crt) PRIVATE_KEY=$(cat pkcs8.key) npm run dev
$ curl -u alice:alice -X POST -v https://8c0fe6b82d8db0.lhr.life/admin/follow/alice/8c0fe6b82d8db0.lhr.life/443/https
$ curl -u alice:alice -X POST --header "Content-Type: application/json" --data @post.json -v https://8c0fe6b82d8db0.lhr.life/admin/create
```